### PR TITLE
Disable business rules and sys field updates

### DIFF
--- a/noauto.js
+++ b/noauto.js
@@ -1,0 +1,2 @@
+gr.autoSysFields(false);  // Do not update sys_updated_by, sys_updated_on, sys_mod_count, sys_created_by, and sys_created_on
+gr.setWorkflow(false);    // Do not run any other business rules


### PR DESCRIPTION
Useful for fix or background scripts before GlideRecord update() to prevent business rules execution and timestamp updates when bulk changing records.