### PR TITLE
Label Styles on Forms

### DIFF
--- a/Label Styles/FieldBold.js
+++ b/Label Styles/FieldBold.js
@@ -1,0 +1,6 @@
+//Client Script to bold a field label.
+//Replace table.field with your desired table and field name
+function onLoad(){
+    var l = g_form.getLabel('table.field');
+    l.style.fontWeight = 'bold';
+}

--- a/Label Styles/FieldFlash.js
+++ b/Label Styles/FieldFlash.js
@@ -1,0 +1,12 @@
+/* Client Script for flashing field name
+Replace table.field with the table name and field name you want to have flash
+Replace color with RGB color or acceptable CSS color like "blue" or "tomato"
+Integer that determines how long the label flashes:
+2 for a 1-second flash
+0 for a 2-second flash
+-2 for a 3-second flash
+-4 for a 4-second flash
+*/
+function onLoad(){
+g_form.flash("table.field","color",0);
+}

--- a/Label Styles/temp file
+++ b/Label Styles/temp file
@@ -1,1 +1,0 @@
-this is a temp file

--- a/Label Styles/temp file
+++ b/Label Styles/temp file
@@ -1,0 +1,1 @@
+this is a temp file


### PR DESCRIPTION
These client scripts may be modified or used wholly as Syntax Macros, and are focused on changing the styles of labels on forms.
One is focused on making the field label bold, while the other is focused on a blinking, colored, highlighted label.