### PR TITLE
Avoid Duplicates on Asset Table and other logic works on Incident table to fetch latest Incidents

### DIFF
--- a/GlideRecord/AvoidDuplicateRecords.js
+++ b/GlideRecord/AvoidDuplicateRecords.js
@@ -1,0 +1,10 @@
+/*prevent having duplicate record in asset table */
+
+/* Use this logic in Before Insert BR , so before it gets imported following script gets execution and abort submission*/
+var duplicaterecord = new GlideRecord('alm_asset');
+duplicaterecord.addQuery('asset_tag', current.asset_tag);
+duplicaterecord.query();
+if (duplicaterecord.next()) {
+gs.addErrorMessage("Asset tag exists already");
+current.setAbortAction(true);
+}

--- a/GlideRecord/SessionImpersonate.js
+++ b/GlideRecord/SessionImpersonate.js
@@ -1,0 +1,50 @@
+/*Logic if you want to perform automation with Admin Profile need to utilise session Impersonate Explained with an use case where we need to Add users to group based on the Request , In request we get the group data and members to be added*/
+var grScReqItem = new GlideRecord('sc_req_item');
+if (grScReqItem.get(current.sys_id)) {
+    var grp = grScReqItem.variables.Group, // Getting group details from catalog replace your variable
+        addCheck = grScReqItem.variables.addmemberlist, //Getting Member to be added from variable
+     
+    var usersArr;
+	var currentuser = gs.getUserID();
+	var adminprofile= gs.getProperty('xyz') // Create an System Property to Store the Admin profile Sysid 
+	var imperuser = gs.getSession().impersonate(adminprofile)// Impersonating to "Admin" to operate the adding members in the group
+
+    if (grp) {
+        if (addCheck) {
+            usersArr = addCheck.toString();
+
+            if (usersArr.length > 32) {
+                usersArr = usersArr.split(',');
+                for (var i in usersArr) {
+                    addUserToGroup(usersArr[i], grp);
+                }
+            } else {
+                usersArr = addCheck;
+                addUserToGroup(usersArr, grp);
+            }
+        }
+
+//Validating if user is part of group or not
+
+function validateUser(user, grp) {
+    var grSUG = new GlideRecord('sys_user_grmember');
+    grSUG.addEncodedQuery("group=" + grp + "^user=" + user);
+    grSUG.query();
+    if (grSUG.hasNext()) {
+        return true;
+    } else {
+        return false;
+    }
+}
+// Adding Member to Group
+function addUserToGroup(user, grp) {
+    var check = validateUser(user, grp);
+    if (!check) {
+        var gr = new GlideRecord('sys_user_grmember');
+        gr.initialize();
+        gr.user = user;
+        gr.group = grp;
+        gr.insert();
+    }
+}
+ gs.getSession().impersonate(currentuser); // Unimpersonating 

--- a/GlideRecord/fetchlast10createdIncident.js
+++ b/GlideRecord/fetchlast10createdIncident.js
@@ -1,0 +1,9 @@
+/* Fetch last 10 created Incidents */
+var latestinc =new GlideRecord("incident");
+latestinc.orderByDesc("sys_created_on");
+latestinc.setLimit(10);
+latestinc.query();
+while(latestinc.next())
+{
+    gs.info(latestinc.getDisplayValue());
+}


### PR DESCRIPTION
Basically this Script Identifies duplicate records based on Asset tag , if already an record exists with Same asset tag it aborts the submission  

Other Logic on Incident Queries Incident table to Print latest 10 created Incidents 