### PR TITLE
Create glidemodalWithHTML.js to open dialog window without UI Page

### DIFF
--- a/GlideDateTime/getlocaldate.js
+++ b/GlideDateTime/getlocaldate.js
@@ -1,0 +1,2 @@
+var gdt = new GlideDateTime();//Initiate the date time object for the current date & time
+gdt.getLocalDate();//Gets the date stored by the date time object, expressed in the standard format, yyyy-MM-dd, and the current user's time zone

--- a/GlideModal/glidemodalWithHTML.js
+++ b/GlideModal/glidemodalWithHTML.js
@@ -1,0 +1,10 @@
+/*
+Don't need to create an UI Page, if you just wanted to show a message in the modal dialog window. The HTML can be directly passed to renderWithContent function
+*/
+
+    var htmlDataToDisplay = '<div class="alert alert-warning" role="alert" style="background-color:#FAC8BF !important;color:#121c4e !important;"><p>THIS IS SAMPLE HTML. ADD YOUR HTML CONTENT HERE. BOOTSTRAP CLASSES WILL ALSO BE SUPPORTED HERE</p></div>';
+    var gm = new GlideModal();
+    //Sets the dialog title
+    gm.setTitle( getMessage('MODAL_WINDOW_TITLE_HERE'));  
+    //Opens the dialog with HTML content supplied as input
+    gm.renderWithContent(htmlDataToDisplay);


### PR DESCRIPTION
Leverage "renderWithContent" function to display message within the Modal window without having to create UI Page. This encourages creating UI page only when there is a need to run client side validation or process server side script based on the action performed in the UI page rendered within glidemodal window