### PR TITLE
getprop.js

### DIFF
--- a/General/getprop.js
+++ b/General/getprop.js
@@ -1,0 +1,1 @@
+gs.getProperty('$0', 'default value'); //enter your property name here, set an Option default parameter


### PR DESCRIPTION
The getProperty() method of the GlideSystem (gs) API accepts one mandatory argument, and one optional one: respectively, the property name, and a default value to return if the property is not found. It returns the value contained within the property or, as you might expect, the value of the second argument if the property is not found. If no second argument is specified and the property is not found, it returns null.