### PR TITLE
Added Get Attachments using GlideSysAttachment API

### DIFF
--- a/GlideSysAttachment/getAttachments.js
+++ b/GlideSysAttachment/getAttachments.js
@@ -1,0 +1,6 @@
+var glideAttachment = new GlideSysAttachment();
+//Get attachments as GlideRecord Objects
+var gAttRec = glideAttachment.getAttachments('<table_name>', '<record_sys_id>'); //Replace <table_name> with your table and <record_sys_id> with sys_id of the record
+while(gAttRec.next()){
+    //Process each attachment record
+}


### PR DESCRIPTION
This macro syntax can be used by the developers to get all attachments on a record and process them one by one.