### PR TITLE
Added two syntax macros for Adding attachment and sending outbound email notification through script.

### DIFF
--- a/GlideSysAttachment/addAttachment.js
+++ b/GlideSysAttachment/addAttachment.js
@@ -1,0 +1,4 @@
+var attachment = new GlideSysAttachment();
+//The syntax for write api is - <GlideRecord record>, <String fileName>, <String contentType>, <String content>
+var attachmentSysId = attachment.write(current, 'file_name.txt', 'text/plain', 'file contents');
+gs.info("Attachment Sys ID: " + attachmentSysId);

--- a/OutboundEmail Action/sendOutboundEmail.js
+++ b/OutboundEmail Action/sendOutboundEmail.js
@@ -1,0 +1,8 @@
+var mail = new GlideEmailOutbound();
+mail.setReplyTo('testing@example.com');
+mail.setFrom('developer@example.com');
+mail.setSubject('ServiceNow Testing'); //setting the subject
+mail.addAddress('cc', 'admin@example.com','John Snow'); //specify the address and name
+mail.setBody('Hello world!');//sets the email body contents
+//mail.addRecipient('hacktoberfest@example.com');//Undocumented in ServiceNow docs but works in global scope.
+mail.save();//Triggeres the outbound notification


### PR DESCRIPTION
The addAttachment.js can be used to add an attachment to record using write api. The 
sendOutboundEmail.js can be used to trigger outbound email notification through scripts. I have personally used and tested in pdi before submitting here. It seems that 'addRecipient' is not documented and it is available in global scope. If run the script in global scope it will trigger the notification ,but in scopped comment the addRecipient. 
Attaching the proof:

![emailOutboundResult](https://github.com/user-attachments/assets/9cd00992-077a-4eca-84aa-7b1d60330682)
Giving link to the SN Community who seemed to have tried this one:
[https://www.servicenow.com/community/app-engine-forum/how-to-send-email-using-glideemailoutbound-api/m-p/2578810](url)